### PR TITLE
Fixed typos

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -17,7 +17,7 @@ Now, the song *shouldn't* clip, indepent of the tracker used to play it.
 
 # Chorus
 
-For this one, you would use the [EDx note delay effect]()!
+For this one, you would use the [EDx note delay effect](./fx.md#edx-note-delay)!
 
 Let's say we have a track playing one instrument, like so:
 

--- a/docs/xm.md
+++ b/docs/xm.md
@@ -262,7 +262,7 @@ There are many, so we'll cover them in ["2.1. EFFECT GLOSSARY"](./fx.md).
 Tracks in XM are interesting because of one thing, and that is their behaviour when muted.
 Upon muting a track in a composition, you are only stopping it from producing a sound.
 Any effects that alter the song (such as [`Fxx`](./fx.md#fxx-set-song-speed) or
-[`Gxx`](./fx.md#gxx-set-global-volume) will still affect the song.
+[`Gxx`](./fx.md#gxx-set-global-volume)) will still affect the song.
 
 # Patterns
 


### PR DESCRIPTION
Hello,

I was reading through the documentation and found a missing `)` and a missing link, here's the corrections.

I also found something I thought was a typo but wasn't so sure if it was a tracker lingo; I've lost because I forgot to save its location but I might find re-reading tomorrow or some day.

Either way, thank you for this awesome documentation.

Entnuo. 