### PR TITLE
Fixed typos, missing links and added a suggestion

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -239,7 +239,7 @@ You can read about the splash screen as a UI element [here](./ui.md#startup).
 Self-explanatory.
 
 You can read about the estimate playtime
-[here](./ui.md#song-title-length-and-peak-window--common-mt-options-toggle-window).
+[here](./ui.md#song-length-tab).
 
 ## Show scopes
 

--- a/docs/elems.md
+++ b/docs/elems.md
@@ -28,7 +28,7 @@ A listview of resolutions MT supports.
 Allows selection of an element from a list, either by double left-clicking or right-clicking on the
 element in the list.
 
-Listviews have a scrollbar, which behavges an audio signal by es similarly to [sliders](#sliders),
+Listviews have a scrollbar, which behaves an audio signal by es similarly to [sliders](#sliders),
 except for the fact they are vertical, and their fine tune buttons have the arrow characters,
 instead of the `+` and `-`.
 

--- a/docs/elems.md
+++ b/docs/elems.md
@@ -98,7 +98,7 @@ This elements works similarly to the text input fields, with the following excep
 Hitting `Esc` resets the text to what it was before the editing.
 
 One example of this type of field is the sample size field in the sample creation popup window,
-visible [here (in the diagram)](./samples.md#new).
+visible [here (in the diagram)](./samples.md#sample-manipulation).
 
 # Drop-down menus
 

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -140,7 +140,7 @@ Effectively, this boosts the volume and high-end.
 ## Generators
 
 Generates a selected signal sample and places it into the selected sample slot.
-Undable using [Undo](#undoredo).
+Undoable using [Undo](#undoredo).
 
 ---
 

--- a/docs/song.md
+++ b/docs/song.md
@@ -129,7 +129,7 @@ We'll get the desired song structure named at the start of the section.
 
 # Saving the song
 
-Now, let's save the song using [the disk operator window]().
+Now, let's save the song using [the disk operator window](./ui.md#disk-operations-window).
 We're setting the type to "Module" and saving an XM module.
 Let's name the export "my-first-song.xm"!
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -27,7 +27,7 @@ There's plenty other ones out there.
 # Information
 
 [The Mod Archive forums](https://modarchive.org/forums/index.php) and the
-[Tracker Music Discord server](https://discord.gg/4TD8mxtw) are my go-tos!
+[Tracker Music Discord server](https://discord.gg/NbHf8VqfM4) are my go-tos!
 
 ---
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -665,7 +665,7 @@ The buttons right of the "Disk op" text field allow the following actions, from 
 7. (`STEP`) Stepping back one directory (similar to #3)
 8. (`DEL`) Deleting the selected file (which can be of any type)
 9. (`MKDIR`) Making a new directory in the current directory
-10. Toggling additional options
+10. (`≡`) Toggling additional options
 11. (`<`/`>`) Toggling the saved directories tab
 12. (`FLIP`) Toggling the two views of the disk operations window
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -294,7 +294,7 @@ The options which don't link to a heading do the following:
 
 | Option     | Description |
 | -          | - |
-| `Save`     | Save the module by owerwriting the module you loaded. If the module is the default empty one that MT loads up with (`Untitled.xm`), this button works the same as [`As...`](). |
+| `Save`     | Save the module by owerwriting the module you loaded. If the module is the default empty one that MT loads up with (`Untitled.xm`), this button works the same as [`As...`](#general-editor-buttons-window). |
 | `Play Sng` | Play the module, from the beginning of the current pattern. Same as `Right Ctrl`. |
 | `Pat`      | Play the current pattern indefinitely, starting from the beginning. Same as `AltGr` (`Right Alt`). |
 | `Pos`      | Play the current pattern indefinitely, starting from the cursor position. Same as `Sh+Enter`. |

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -294,7 +294,7 @@ The options which don't link to a heading do the following:
 
 | Option     | Description |
 | -          | - |
-| `Save`     | Save the module by owerwriting the module you loaded. If the module is the default empty one that MT loads up with (`Untitled.xm`), this button works the same as [`As...`](#general-editor-buttons-window). |
+| `Save`     | Save the module by owerwriting the module you loaded. If the module is the default empty one that MT loads up with (`Untitled.xm`), this button works the same as `As...`. |
 | `Play Sng` | Play the module, from the beginning of the current pattern. Same as `Right Ctrl`. |
 | `Pat`      | Play the current pattern indefinitely, starting from the beginning. Same as `AltGr` (`Right Alt`). |
 | `Pos`      | Play the current pattern indefinitely, starting from the cursor position. Same as `Sh+Enter`. |

--- a/docs/xm.md
+++ b/docs/xm.md
@@ -108,7 +108,7 @@ The default value is 0 (`+000`).
 ## Fadeout
 
 A value that determines how quickly the volume of the sample drops to 0 after the
-[Note-off](#fadeout).
+[Note-off](#note-off).
 
 Works only when the volume envelope is on.
 


### PR DESCRIPTION
Hi again,

here are the changes I was talking about in my last comment in #1 . Some of these changes I thought would be better and more specific than before, i.e: when talking about estimate time, link to its section instead its general section. Also I thought would be nice to use `≡` as a hamburger menu representation instead of just text.

Anyway, if you disagree or have a better suggestion please leave a comment.

Have a nice day/night! :)